### PR TITLE
Some modes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,29 +3,48 @@ SRCDIR = src
 OBJDIR = obj
 BINDIR = bin
 
-# Main program
+# Main programs
 MAIN = tp-link-decrypt
+GEN = gen_keys_for_usr_conf_data
 
-# Find all source files
-SOURCES := $(shell find $(SRCDIR) -name '*.c')
+# By default, build both programs:
+all: $(BINDIR)/$(MAIN) $(BINDIR)/$(GEN)
+
+# Find all .c source files in SRCDIR (for tp-link-decrypt).
+SOURCES := $(shell find $(SRCDIR) -name '*.c' -and -not -name 'gen_keys_for_usr_conf_data.c')
 OBJECTS := $(SOURCES:$(SRCDIR)/%.c=$(OBJDIR)/%.o)
 
 # Compiler and flags
 CC = gcc
 CFLAGS = -Wno-implicit-function-declaration -I$(SRCDIR)
 
-# Main target
+###############################################################################
+# 1) Build the tp-link-decrypt program
+###############################################################################
 $(BINDIR)/$(MAIN): $(OBJECTS)
 	@mkdir -p $(BINDIR)
 	$(CC) $(OBJECTS) -o $@
 
-# Rule for object files
+###############################################################################
+# 2) Build the gen_keys_for_usr_conf_data program
+###############################################################################
+
+$(BINDIR)/$(GEN): $(OBJDIR)/gen_keys_for_usr_conf_data.o
+	@mkdir -p $(BINDIR)
+	$(CC) $(CFLAGS) $^ -o $@
+
+# We already have a pattern rule for building .o from .c,
+# so it will handle gen_keys_for_usr_conf_data.c automatically.
+
+###############################################################################
+# Pattern rule for any .c -> .o
+###############################################################################
 $(OBJDIR)/%.o: $(SRCDIR)/%.c
 	@mkdir -p $(@D)
 	$(CC) $(CFLAGS) -c $< -o $@
 
-# Clean rule
 clean:
 	rm -rf $(OBJDIR) $(BINDIR)
 
-.PHONY: clean
+.PHONY: clean all
+

--- a/README
+++ b/README
@@ -5,8 +5,17 @@
 
 3.  Run `make`
 
-Decrypt with   bin/tp-link-decrypt <fw file>
+Decrypt with   `./bin/tp-link-decrypt <fw file>` then use `binwalk -e <dec bin>` to extract the found signatures
 
+For decryption usr_conf_data:
+    
+    1. Run `./bin/gen_keys_for_usr_conf_data <dir>`, where `<dir>` is directory with signatures
+
+    2. Run `./decrypt_usr_conf_data.sh` for decryption
+    
+    3. See the results in directory with name `_usr_conf_data_dec.extracted`
+
+For more info check USR_DATA_DEC_EXPL file
 
 
 NOTE:

--- a/README
+++ b/README
@@ -1,7 +1,9 @@
 
-1.  Run ./extract_keys.sh  to extract RSA keys from included TP-Link Firmware
+1.  Run `sudo ./preinstall.sh`
 
-2.  Run make
+2.  Run `./extract_keys.sh`  to extract RSA keys from included TP-Link Firmware
+
+3.  Run `make`
 
 Decrypt with   bin/tp-link-decrypt <fw file>
 

--- a/USR_DATA_DEC_EXPL.md
+++ b/USR_DATA_DEC_EXPL.md
@@ -1,0 +1,50 @@
+In the firmware signatures, you may find a `squashfs-root` or similar directory that contains system executables. 
+One interesting one is `/etc/uc_convert`, which accesses the `/etc/usr_conf_data` file. 
+Upon examination, it was discovered that it generates a DES key to decrypt this file so that the device can use the data it contains for user authentication and other operations.
+If we look at the logic of interaction between the client and the camera, we can see that when granting access to the video stream, the user undergoes Digest authentication.
+Digest authentication has several types, each of which depends on the `qop` parameter passed by the server and the mode of *MD5* hashing algorithm.
+The general form of response generation looks like `respone=MD5(HA1:middle:HA2)`.
+As you can see, the response is formed of three parts, each of which is generated according to the following logic:
+- HA1:
+    - If the algorithm mode is not specified or is declared as MD5, then `HA1=MD5(username:realm:password)`
+	- If the hashing algorithm mode is MD5-sess, then `HA1=(MD5(username:realm:password):nonce:cnonce)`
+- HA2:
+    - If the qop parameter is not specified or is equal to "auth", then `HA2=MD5(method:digestURI)`
+    - If the qop parameter is "auth-int", then `HA2=MD5(method:digestURI:MD5(entityBody))`
+- Middle:
+    - If the qop parameter is "auth" or "auth-int", then `middle=nonce:nonceCount:clientNonce:qop`. Then the response will be produced as follows: 
+`response=MD5(HA1:nonce:nonceCount:clientNonce:qop:HA2)`
+    - If the qop parameter is not specified, then `middle=nonce`, so the response is generated using the `MD5(HA1:nonce:HA2)` formula.
+In our case, the device transmits: 
+    - realm = TP-LINK IP-Camera
+    - algorithm = MD5
+    - qop = auth
+    - nonce = <some string>
+The client sends:
+    - response = <result of auth>
+    - uri = /stream
+    - realm = <same realm>
+    - qop = auth
+    - nonce = <some string>
+    - cnonce = <some string>
+    - nc = <some string>
+So the response output will be calculated as `response = MD5(MD5(username:realm:password):nonce:nonceCount:cnonce:qop:MD5(method:digestURI))`.
+All parameters except password are passed in plaintext. It is in the file usr_conf_data that password is stored, which is necessary for Digest Auth.
+
+The logic of `uc_convert` looks like this (taken from `Tapo_C200v1_en_1.0.10_Build_200520_Rel.45325n_1594713621606.bin firmware`):
+
+    - `/bin/uc_convert` reads encrypted user config from flash address 0x40000 - 0x50000, which is the same as partition "config".
+
+    - Decryption key is read from flash address 0x600c0, with length 0xc (12 bytes). The content is "C200 1.0" with some trailing null bytes.
+
+    - "C200 1.0" then goes through a hash function, generating hash value : "5982a0a3".
+
+    - Decryption function calls "des_min_do()", which indicates user config is encrypted using DES. DES has key length of 64 bit (8 bytes), so we will have to convert "5982a0a3" into hex value - "3539383261306133".
+
+The logic of the `gen_keys_for_usr_conf_data` is to try to find the `usr_conf_data` file in the signatures. 
+If the program manages to find this file, it proceeds to the DES-key generation stage, using a substring in the name of the directory that contains the signatures (for example, for the directory `_Tapo_C200v4_en_1.3.7_Build_230627_Rel.41997n_up_boot-signed_1691143640985.bin.dec.extracted`, the substring `C200v4` is taken and translated into the form `C200 4.0`) and the results are written to a text file.
+If no substring in the directory name is found, the program will ask you to enter the string for DES manually. 
+Next, the script takes the data from the file, decrypts the file and extracts the found signature using binwalk. 
+After that, you can view the data it contains.
+
+*It was tested on firmware for the C200 model with hardware versions 1-4. More tests are needed*

--- a/USR_DATA_DEC_EXPL.md
+++ b/USR_DATA_DEC_EXPL.md
@@ -1,9 +1,15 @@
 In the firmware signatures, you may find a `squashfs-root` or similar directory that contains system executables. 
+
 One interesting one is `/etc/uc_convert`, which accesses the `/etc/usr_conf_data` file. 
+
 Upon examination, it was discovered that it generates a DES key to decrypt this file so that the device can use the data it contains for user authentication and other operations.
+
 If we look at the logic of interaction between the client and the camera, we can see that when granting access to the video stream, the user undergoes Digest authentication.
+
 Digest authentication has several types, each of which depends on the `qop` parameter passed by the server and the mode of *MD5* hashing algorithm.
+
 The general form of response generation looks like `respone=MD5(HA1:middle:HA2)`.
+
 As you can see, the response is formed of three parts, each of which is generated according to the following logic:
 - HA1:
     - If the algorithm mode is not specified or is declared as MD5, then `HA1=MD5(username:realm:password)`
@@ -17,36 +23,38 @@ As you can see, the response is formed of three parts, each of which is generate
     - If the qop parameter is not specified, then `middle=nonce`, so the response is generated using the `MD5(HA1:nonce:HA2)` formula.
 
 In our case, the device transmits: 
-    - realm = TP-LINK IP-Camera
-    - algorithm = MD5
-    - qop = auth
-    - nonce = <some string>
+- realm = TP-LINK IP-Camera
+- algorithm = MD5
+- qop = auth
+- nonce = <some string>
 The client sends:
-    - response = <result of auth>
-    - uri = /stream
-    - realm = <same realm>
-    - qop = auth
-    - nonce = <some string>
-    - cnonce = <some string>
-    - nc = <some string>
+- response = <result of auth>
+- uri = /stream
+- realm = <same realm>
+- qop = auth
+- nonce = <some string>
+- cnonce = <some string>
+- nc = <some string>
 
 So the response output will be calculated as `response = MD5(MD5(username:realm:password):nonce:nonceCount:cnonce:qop:MD5(method:digestURI))`.
-All parameters except password are passed in plaintext. It is in the file usr_conf_data that password is stored, which is necessary for Digest Auth.
+
+All parameters except password are passed in plaintext. It is in the file `usr_conf_data` that password is stored, which is necessary for Digest Auth.
 
 The logic of `uc_convert` looks like this (taken from `Tapo_C200v1_en_1.0.10_Build_200520_Rel.45325n_1594713621606.bin firmware`):
 
-    - `/bin/uc_convert` reads encrypted user config from flash address 0x40000 - 0x50000, which is the same as partition "config".
-
-    - Decryption key is read from flash address 0x600c0, with length 0xc (12 bytes). The content is "C200 1.0" with some trailing null bytes.
-
-    - "C200 1.0" then goes through a hash function, generating hash value : "5982a0a3".
-
-    - Decryption function calls "des_min_do()", which indicates user config is encrypted using DES. DES has key length of 64 bit (8 bytes), so we will have to convert "5982a0a3" into hex value - "3539383261306133".
+- `/bin/uc_convert` reads encrypted user config from flash address 0x40000 - 0x50000, which is the same as partition "config".
+- Decryption key is read from flash address 0x600c0, with length 0xc (12 bytes). The content is "C200 1.0" with some trailing null bytes.
+- "C200 1.0" then goes through a hash function, generating hash value : "5982a0a3".
+- Decryption function calls "des_min_do()", which indicates user config is encrypted using DES. DES has key length of 64 bit (8 bytes), so we will have to convert "5982a0a3" into hex value - "3539383261306133".
 
 The logic of the `gen_keys_for_usr_conf_data` is to try to find the `usr_conf_data` file in the signatures. 
+
 If the program manages to find this file, it proceeds to the DES-key generation stage, using a substring in the name of the directory that contains the signatures (for example, for the directory `_Tapo_C200v4_en_1.3.7_Build_230627_Rel.41997n_up_boot-signed_1691143640985.bin.dec.extracted`, the substring `C200v4` is taken and translated into the form `C200 4.0`) and the results are written to a text file.
+
 If no substring in the directory name is found, the program will ask you to enter the string for DES manually. 
+
 Next, the script takes the data from the file, decrypts the file and extracts the found signature using binwalk. 
+
 After that, you can view the data it contains.
 
 *It was tested on firmware for the C200 model with hardware versions 1-4. More tests are needed*

--- a/USR_DATA_DEC_EXPL.md
+++ b/USR_DATA_DEC_EXPL.md
@@ -15,6 +15,7 @@ As you can see, the response is formed of three parts, each of which is generate
     - If the qop parameter is "auth" or "auth-int", then `middle=nonce:nonceCount:clientNonce:qop`. Then the response will be produced as follows: 
 `response=MD5(HA1:nonce:nonceCount:clientNonce:qop:HA2)`
     - If the qop parameter is not specified, then `middle=nonce`, so the response is generated using the `MD5(HA1:nonce:HA2)` formula.
+
 In our case, the device transmits: 
     - realm = TP-LINK IP-Camera
     - algorithm = MD5
@@ -28,6 +29,7 @@ The client sends:
     - nonce = <some string>
     - cnonce = <some string>
     - nc = <some string>
+
 So the response output will be calculated as `response = MD5(MD5(username:realm:password):nonce:nonceCount:cnonce:qop:MD5(method:digestURI))`.
 All parameters except password are passed in plaintext. It is in the file usr_conf_data that password is stored, which is necessary for Digest Auth.
 

--- a/decrypt_usr_conf_data.sh
+++ b/decrypt_usr_conf_data.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+#
+# 1) Find usr_conf_data
+#
+echo "Searching for 'usr_conf_data' in subdirectories..."
+USR_CONF_PATH="$(find . -type f -name 'usr_conf_data' | head -n 1)"
+
+if [ -z "$USR_CONF_PATH" ]; then
+  echo "ERROR: 'usr_conf_data' not found in any subdirectory."
+  exit 1
+fi
+
+echo "Found: $USR_CONF_PATH"
+
+#
+# 2) Extract the last (or first) 'Hex value key' from DES_key_n_hex.txt
+#
+# - tail -1 берёт последнюю найденную строку с 'Hex value key:'
+#   Если нужно брать первую, замените на 'head -n 1'
+#
+HEX_KEY="$(grep 'Hex value key:' DES_key_n_hex.txt | tail -n 1 | awk '{print $4}')"
+
+if [ -z "$HEX_KEY" ]; then
+  echo "ERROR: Could not find 'Hex value key:' line in DES_key_n_hex.txt."
+  exit 1
+fi
+
+echo "Using hex key from file: $HEX_KEY"
+
+#
+# 3) Decrypt using openssl des-ecb
+#
+echo "Decrypting $USR_CONF_PATH -> usr_conf_data_dec ..."
+openssl enc -d -des-ecb -nopad -K "$HEX_KEY" -in "$USR_CONF_PATH" -out usr_conf_data_dec -provider legacy
+
+if [ $? -ne 0 ]; then
+  echo "ERROR: openssl decryption failed."
+  exit 1
+fi
+
+echo "Decryption complete: usr_conf_data_dec"
+
+#
+# 4) Run binwalk -e
+#
+echo "Running binwalk -e on usr_conf_data_dec ..."
+binwalk -e usr_conf_data_dec
+

--- a/src/changelog.md
+++ b/src/changelog.md
@@ -1,0 +1,24 @@
+## tp-link-decrypt changes
+
+Utilization of the cleanup function:
+    - Universal resource freeing function.
+    - Ensures that memory is cleaned and freed in any situation.
+
+Safe buffer handling:
+    - Uses snprintf to create the output file name, preventing buffer overflow.
+
+Read and write error handling:
+    - Checks the result of fread and fwrite to ensure that the data was processed correctly.
+
+Memory leak prevention:
+    - Any allocated memory is freed even in case of an error.
+
+Clearing sensitive data:
+    - Flash memory is cleared with memset before being freed.
+
+Checking all memory allocation calls:
+    - Added check for success of malloc, calloc calls
+
+## New
+
+Added `gen_keys_for_usr_conf_data.c` and `decrypt_usr_conf_data.sh` to find and decrypt `etc/usr_conf_data`

--- a/src/gen_keys_for_usr_conf_data.c
+++ b/src/gen_keys_for_usr_conf_data.c
@@ -1,0 +1,271 @@
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <dirent.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <stdbool.h>
+#include <ctype.h>
+
+/**
+ * Calculates a 32-bit hash of the given string.
+ * - Skips double quotes (").
+ * - Uses a modulo-based approach with prime 0x7fffffff.
+ */
+unsigned int hash(const char *str) 
+{
+    if (str == NULL) 
+    {
+        puts("str is null ptr");
+        return 0;
+    }
+
+    unsigned int hash_value = 0;
+    
+    while (*str != '\0') 
+    {
+        if (*str != '"') 
+        {
+            hash_value = ((hash_value * 31) + (unsigned char)(*str)) % 0x7fffffff;
+        }
+        str++;
+    }
+    return hash_value;
+}
+
+/**
+ * Converts a 32-bit unsigned integer (key) to a standard 8-character hex string,
+ * then each character of that hex string is converted to two hexadecimal digits
+ * representing its ASCII code.
+ * 
+ * For instance, if key = 0x5982abe6, the standard hex string is "5982abe6".
+ * Each character of that string is then converted to its ASCII code in hex:
+ * '5' -> 0x35, '9' -> 0x39, '8' -> 0x38, etc.
+ * 
+ * The final result would be 16 hexadecimal digits, for example: "3539383261626536".
+ */
+void convert_to_ascii_hex(unsigned int key, char *hex_value) 
+{
+    // Step 1: create a normal 8-char hex string for the integer (e.g., "5982abe6")
+    char tmp[9]; // 8 characters + null terminator
+    snprintf(tmp, sizeof(tmp), "%08x", key);
+
+    // Step 2: convert each character to its ASCII code in hex
+    // '5' (0x35) -> "35", '9' (0x39) -> "39", etc.
+    for (int i = 0; i < 8; i++) 
+    {
+        unsigned char c = (unsigned char) tmp[i];
+        // Write ASCII code of 'c' as two hex digits
+        sprintf(&hex_value[2 * i], "%02x", c);
+    }
+    // Terminate the string (16 hex characters + null)
+    hex_value[16] = '\0';
+}
+
+/**
+ * Recursively searches for the file "etc/usr_conf_data" within subdirectories
+ * of 'start_dir'.
+ * - If found, returns true and copies the file path to 'result'.
+ * - Otherwise, returns false.
+ */
+bool find_usr_conf_data(const char *start_dir, char *result, size_t result_size) 
+{
+    DIR *d = opendir(start_dir);
+    if (!d) 
+    {
+        return false;
+    }
+
+    struct dirent *entry;
+    while ((entry = readdir(d)) != NULL) 
+    {
+        // Skip "." and ".."
+        if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0) 
+        {
+            continue;
+        }
+
+        char path[1024];
+        snprintf(path, sizeof(path), "%s/%s", start_dir, entry->d_name);
+
+        struct stat st;
+        if (stat(path, &st) == 0 && S_ISDIR(st.st_mode)) 
+        {
+            // Form "path/etc/usr_conf_data"
+            char test_path[2048];
+            snprintf(test_path, sizeof(test_path), "%s/etc/usr_conf_data", path);
+
+            // Check if the file exists
+            if (access(test_path, F_OK) == 0) 
+            {
+                // Found the file
+                strncpy(result, test_path, result_size);
+                result[result_size - 1] = '\0'; // ensure null-termination
+                closedir(d);
+                return true;
+            }
+
+            // Otherwise, recurse into this subdirectory
+            if (find_usr_conf_data(path, result, result_size)) 
+            {
+                closedir(d);
+                return true;
+            }
+        }
+    }
+
+    closedir(d);
+    return false;
+}
+
+/**
+ * Attempts to find a pattern like:
+ *   'C' + (one or more digits) + 'v' + (one or more digits)
+ * For example:
+ *   C210v1  -> returns "C210 1.0"
+ *   C220v5  -> returns "C220 5.0"
+ *   C200v4  -> returns "C200 4.0"
+ * 
+ * Returns true if the pattern is found, otherwise false.
+ * 
+ * Logic:
+ *   1. Search for 'C' in the input string.
+ *   2. After 'C', read any digits (this becomes the model, e.g., 210, 220, etc.).
+ *   3. Expect a 'v', then read version digits (e.g., 1, 2, 5, etc.).
+ *   4. Construct a final string like "C210 1.0".
+ */
+bool extractCModelVersion(const char *input, char *output, size_t output_size) 
+{
+    // Find each 'C' in the string
+    const char *ptr = input;
+    while ((ptr = strchr(ptr, 'C')) != NULL) 
+    {
+        ptr++; // move past 'C'
+
+        // Gather digits after 'C'
+        char modelDigits[32];
+        int modelIdx = 0;
+        while (isdigit((unsigned char)*ptr) && modelIdx < (int)(sizeof(modelDigits) - 1)) 
+        {
+            modelDigits[modelIdx++] = *ptr;
+            ptr++;
+        }
+        modelDigits[modelIdx] = '\0';
+
+        if (modelIdx == 0) 
+        {
+            // No digits immediately after 'C' -> try next 'C'
+            continue;
+        }
+
+        // Expect 'v' next
+        if (*ptr != 'v') 
+        {
+            // No 'v' -> try next 'C' in the outer loop
+            continue;
+        }
+
+        // Found 'v', move on
+        ptr++;
+
+        // Gather digits after 'v'
+        char versionDigits[32];
+        int versionIdx = 0;
+        while (isdigit((unsigned char)*ptr) && versionIdx < (int)(sizeof(versionDigits) - 1)) 
+        {
+            versionDigits[versionIdx++] = *ptr;
+            ptr++;
+        }
+        versionDigits[versionIdx] = '\0';
+
+        if (versionIdx == 0) 
+        {
+            // No digits after 'v' -> not a valid pattern
+            continue;
+        }
+
+        // Construct "C<modelDigits> <versionDigits>.0"
+        snprintf(output, output_size, "C%s %s.0", modelDigits, versionDigits);
+        return true;
+    }
+
+    // No match found
+    return false;
+}
+
+int main(int argc, char *argv[]) 
+{
+    if (argc != 2) 
+    {
+        fprintf(stderr, "Usage: %s <extracted_directory>\n", argv[0]);
+        return 1;
+    }
+
+    // 1) Attempt to automatically extract a substring like "C210v1", "C220v5", etc.
+    char auto_str[256];
+    bool got_auto_str = extractCModelVersion(argv[1], auto_str, sizeof(auto_str));
+
+    char final_str[256];
+    if (got_auto_str) 
+    {
+        // Successfully found something like "C220 5.0"
+        strncpy(final_str, auto_str, sizeof(final_str));
+        final_str[sizeof(final_str) - 1] = '\0';
+        printf("Auto-detected string for DES key: %s\n", final_str);
+    } 
+    else 
+    {
+        // No matching substring found; ask for user input
+        printf("Enter the string to generate DES key: ");
+        if (fgets(final_str, sizeof(final_str), stdin) == NULL) 
+        {
+            fprintf(stderr, "Error reading input\n");
+            return 1;
+        }
+        // Remove trailing newline if present
+        size_t len = strlen(final_str);
+        
+        if (len > 0 && final_str[len - 1] == '\n') 
+        {
+            final_str[len - 1] = '\0';
+        }
+    }
+
+    // 2) Recursively search for etc/usr_conf_data in the given directory
+    char usr_conf_path[2048];
+    
+    if (!find_usr_conf_data(argv[1], usr_conf_path, sizeof(usr_conf_path))) 
+    {
+        fprintf(stderr, "File etc/usr_conf_data not found in subdirectories of: %s\n", argv[1]);
+        return 1;
+    }
+
+    printf("File found: %s\n", usr_conf_path);
+
+    // 3) Compute the 32-bit hash of the selected string
+    unsigned int key = hash(final_str);
+    printf("Key: %08x\n", key);
+
+    // 4) Convert the key to ASCII-hex (each character -> 2 hex digits for its ASCII code)
+    char hex_key[17];
+    convert_to_ascii_hex(key, hex_key);
+    printf("Hex value key: %s\n", hex_key);
+
+    // 5) Append the key and hex to "DES_key_n_hex.txt"
+    FILE *fp = fopen("DES_key_n_hex.txt", "a");
+    if (fp == NULL) 
+    {
+        fprintf(stderr, "Failed to open DES_key_n_hex.txt for writing.\n");
+        return 1;
+    }
+
+    // Write the key and hex value, plus a separator or newline.
+    fprintf(fp, "Key: %08x\n", key);
+    fprintf(fp, "Hex value key: %s\n", hex_key);
+    fprintf(fp, "----------------------\n");
+
+    fclose(fp);
+
+    return 0;
+}
+


### PR DESCRIPTION
## tp-link-decrypt changes

Utilization of the cleanup function:
    - Universal resource freeing function.
    - Ensures that memory is cleaned and freed in any situation.

Safe buffer handling:
    - Uses `snprintf` to create the output file name, preventing buffer overflow.

Read and write error handling:
    - Checks the result of `fread` and `fwrite` to ensure that the data was processed correctly.

Memory leak prevention:
    - Any allocated memory is freed even in case of an error.

Clearing sensitive data:
    - Flash memory is cleared with memset before being freed.

Checking all memory allocation calls:
    - Added check for success of `malloc`, `calloc` calls

## New

Added `gen_keys_for_usr_conf_data.c` and `decrypt_usr_conf_data.sh` to find and decrypt `etc/usr_conf_data`
